### PR TITLE
Add correct app store links for Signal / RedPhone

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@ smartbanner: true
 		      </li>
 		    </ul>
 
-		    <a href="">
+		    <a href="https://itunes.apple.com/us/app/signal-private-messenger/id874139669">
 		      <img alt="iPhone app on App Store"
 			   src="{% asset_path body/appstore.png %}"/>
 		    </a>
@@ -118,12 +118,12 @@ smartbanner: true
 		      </li>
 		    </ul>
 
-		    <a href="">
+		    <a href="https://itunes.apple.com/us/app/signal-private-messenger/id874139669">
 		      <img alt="iPhone app on App Store"
 			   src="{% asset_path body/appstore.png %}"/>
 		    </a>
 
-		    <a href="https://play.google.com/store/apps/details?id=org.thoughtcrime.securesms">
+		    <a href="https://play.google.com/store/apps/details?id=org.thoughtcrime.redphone">
 		      <img alt="Android app on Google Play"
 			   src="https://developer.android.com/images/brand/en_app_rgb_wo_60.png" />
 		    </a>


### PR DESCRIPTION
Congratulations on your beautiful new website!

The app store links for Signal on the index page were missing.

I also changed the Google Play-link in the "Private Calling"-section
to point to RedPhone, not sure if this is wanted or not.